### PR TITLE
feat: add currentTab options

### DIFF
--- a/src/assets/locales/en/messages.json
+++ b/src/assets/locales/en/messages.json
@@ -329,6 +329,11 @@
     "description": "Value of the option."
   },
 
+  "optionTitle_onlyCurrentTab": {
+    "message": "Only current tab",
+    "description": "Title of the option."
+  },
+
   "optionTitle_clearSince": {
     "message": "Time range",
     "description": "Title of the option."
@@ -506,6 +511,11 @@
 
   "buttonTooltip_clearSince": {
     "message": "Time range",
+    "description": "Tooltip of the button."
+  },
+
+  "buttonTooltip_onlyCurrentTab": {
+    "message": "Only current tab",
     "description": "Tooltip of the button."
   },
 

--- a/src/assets/manifest/chrome.json
+++ b/src/assets/manifest/chrome.json
@@ -9,7 +9,7 @@
 
   "minimum_chrome_version": "123.0",
 
-  "permissions": ["browsingData", "notifications", "storage"],
+  "permissions": ["browsingData", "notifications", "storage", "tabs"],
 
   "content_security_policy": {
     "extension_pages": "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src * data:; connect-src *; object-src 'none'; media-src 'none'; child-src 'none'; form-action 'none';"

--- a/src/assets/manifest/edge.json
+++ b/src/assets/manifest/edge.json
@@ -9,7 +9,7 @@
 
   "minimum_chrome_version": "123.0",
 
-  "permissions": ["browsingData", "notifications", "storage"],
+  "permissions": ["browsingData", "notifications", "storage", "tabs"],
 
   "content_security_policy": "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src * data:; connect-src *; object-src 'none'; media-src 'none'; child-src 'none'; form-action 'none';",
 

--- a/src/assets/manifest/firefox.json
+++ b/src/assets/manifest/firefox.json
@@ -14,7 +14,7 @@
     }
   },
 
-  "permissions": ["browsingData", "notifications", "storage"],
+  "permissions": ["browsingData", "notifications", "storage", "tabs"],
 
   "content_security_policy": "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src * data:; connect-src *; object-src 'none'; media-src 'none'; child-src 'none'; form-action 'none'; upgrade-insecure-requests;",
 

--- a/src/assets/manifest/opera.json
+++ b/src/assets/manifest/opera.json
@@ -9,7 +9,7 @@
 
   "minimum_opera_version": "109.0",
 
-  "permissions": ["browsingData", "notifications", "storage"],
+  "permissions": ["browsingData", "notifications", "storage", "tabs"],
 
   "content_security_policy": "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src * data:; connect-src *; object-src 'none'; media-src 'none'; child-src 'none'; form-action 'none';",
 

--- a/src/options/App.vue
+++ b/src/options/App.vue
@@ -112,6 +112,12 @@
             v-model="options.confirmDataRemoval"
           ></vn-switch>
         </div>
+        <div class="option">
+          <vn-switch
+            :label="getText('optionTitle_onlyCurrentTab')"
+            v-model="options.onlyCurrentTab"
+          ></vn-switch>
+        </div>
         <div class="option" v-if="enableContributions">
           <vn-switch
             :label="getText('optionTitle_showContribPage')"
@@ -217,6 +223,7 @@ export default {
         notifyOnSuccess: false,
         showDataTypeIcons: false,
         confirmDataRemoval: false,
+        onlyCurrentTab: false,
         appTheme: false,
         showContribPage: false
       }

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -3,6 +3,7 @@ const optionKeys = [
   'disabledDataTypes',
   'clearAllDataTypesAction',
   'clearSince',
+  'onlyCurrentTab',
   'closeTabs',
   'closePinnedTabs',
   'reloadTabs',


### PR DESCRIPTION

<img width="460" alt="image" src="https://github.com/user-attachments/assets/fd829968-d688-4f68-91ec-4cbd02707b6b" />
if open onlyCurrentTab options, when click clear, just current tabs data will be clear.